### PR TITLE
remove auto-translated warning and ClonOS auto translation rewritten

### DIFF
--- a/en/cbsdweb.html
+++ b/en/cbsdweb.html
@@ -1,20 +1,34 @@
 <!--# include file="_start.html" -->
 <!--# include file="currentver.html" -->
-<!--# include file="/en/translate.html" -->
 	<h1><span>WEB interface</span></h1>
-	
-	<h2><a name="knowit">WEB interface</a></h2>
+	<h2><a name="knowit">Web based interface</a></h2>
 	<div class="block">
-		<p>WEB interface project for <strong>CBSD</strong> called <strong>ClonOS</strong> and implemented as a separate FreeBSD distribution<p>
-		<p>Site of the project: <a href="https://clonos.tekroutine.com" target="_blank">clonos.tekroutine.com</a></p>
-		<p>Also, when we obtain a certain number of comments about the ClonOS from users, it will be published in the FreeBSD ports</p>
-		<p>At present it is not production-ready product, however, the part of functional is stable, e.g.:</p>
+    <p><strong>CBSD</strong> offers a web based interface called <strong>ClonOS</strong>.
+      <strong>ClonOS</strong> is developed independently to be a standalone 
+      platform to manage and create virtual environments in FreeBSD. <strong>ClonOS</strong> 
+      itself is also FreeBSD based, and can be installed and run as a purpose 
+      built FreeBSD distribution.
+    </p>
+    <p>More information can be found on the <strong>ClonOS</strong> website: 
+      <a href="https://clonos.tekroutine.com" target="_blank">clonos.tekroutine.com</a>
+    </p>
+    <p>Once enough positive feedback about <strong>ClonOS</strong> is received, 
+      and the developers feel it stable enough, it will be available via the 
+      FreeBSD ports tree.
+    </p>
+    <p>While <strong>ClonOS</strong> is not currently considered to be production
+      ready, the following features are functionally stable;
+    </p>
 		<ul>
-			<li>WEB interface to create and manage jail</li>
-			<li>WEB interface for bhyve</li>
-			<li>WEB interface for CBSD forms (helpers)</li>
-			<li>WEB interface to work with FreeBSD sources and bases</li>
+			<li>Interface to create and manage jails</li>
+			<li>Interface for manage bhyve</li>
+			<li>Interface to CBSD forms (Helpers to assist with common tasks)</li>
+			<li>Interface to work with/configure FreeBSD sources and bases</li>
 		</ul>
-		<p>The developers are very interested in testing and feedback</p>
+    <p>The developers are very interested in feedback by those using <strong>ClonOS</strong>. 
+      The more testing, and feedback provided, the quicker <strong>ClonOS</strong>
+      will make it into the ports tree. Please click <a href="https://www.bsdstore.ru/en/feedback.html" target="_blank">here</a>
+      for more information on submitting feedback.
+    </p>
 	</div>
 <!--# include file="_end.html" -->

--- a/en/docs.html
+++ b/en/docs.html
@@ -1,5 +1,4 @@
 <!--# include file="_start.html" -->
-<!--# include file="translate.html" -->
 	<h1><span>Documentation</span></h1>
 	<h2><a name="docs">General information</a></h2>
 	<div class="block">


### PR DESCRIPTION
The automatically translated warning is not needed on the docs.html page.