### PR TITLE
Delete articles.html

### DIFF
--- a/de/articles.html
+++ b/de/articles.html
@@ -1,1 +1,0 @@
-<!--# include file="/de/articles.html" -->


### PR DESCRIPTION
the "content" produces
> [an error occurred while processing the directive]
. printing the 404 content (like /de/screenshots.html because there is no /de/screenshots.html seems to be better.)